### PR TITLE
Embeds support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 coverage
 components
 webcm.config.ts
+kv/*
+
+!.gitkeep

--- a/lib/browser/embedHeight.js
+++ b/lib/browser/embedHeight.js
@@ -1,0 +1,7 @@
+window.addEventListener(
+  'message',
+  ({ data }) => {
+    if (data.webcmUpdateHeight) document.getElementById(data.id).height = data.h
+  },
+  false
+)

--- a/lib/manager.ts
+++ b/lib/manager.ts
@@ -80,7 +80,7 @@ export class ManagerGeneric {
   }) {
     this.componentsFolderPath =
       Context.componentsFolderPath || path.join(__dirname, '..', 'components')
-    this.requiredSnippets = ['track']
+    this.requiredSnippets = ['track', 'embedHeight']
     this.registeredWidgets = []
     this.registeredEmbeds = {}
     this.listeners = {}
@@ -278,8 +278,16 @@ export class ManagerGeneric {
       const name = parameters['component-embed']
       if (this.registeredEmbeds[name]) {
         const embed = await this.registeredEmbeds[name]({ parameters })
-        const iframe = `<iframe sandbox="allow-scripts" src="about:blank" style="border: 0"srcDoc="${embed}"></iframe>`
-        div.innerHTML = iframe
+        const uuid = 'embed-' + crypto.randomUUID()
+        div.innerHTML = `<iframe id="${uuid}" style="width: 100%; border: 0;" src="data:text/html;charset=UTF-8,${encodeURIComponent(
+          embed +
+            `<script>
+const webcmUpdateHeight = () => parent.postMessage({webcmUpdateHeight: true, id: '${uuid}', h: document.body.scrollHeight }, '*');
+addEventListener('load', webcmUpdateHeight);
+addEventListener('resize', webcmUpdateHeight);
+</script>`
+        )}"></iframe>
+`
       }
     }
 
@@ -367,7 +375,7 @@ export class Manager implements MCManager {
   }
 
   registerEmbed(name: string, callback: EmbedCallback) {
-    this.#generic.registeredEmbeds[this.#component + '__' + name] = callback
+    this.#generic.registeredEmbeds[this.#component + '-' + name] = callback
     return true
   }
 

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -177,11 +177,13 @@ export const startServer = async (
       manager.proxiedEndpoints[component]
     )) {
       const proxyEndpoint = '/webcm/' + component + path
-      app.all(proxyEndpoint, async (req, res, next) => {
+      app.all(proxyEndpoint + '*', async (req, res, next) => {
+
         const proxy = createProxyMiddleware({
-          target: proxyTarget + req.path.slice(proxyEndpoint.length - 2),
+          target: proxyTarget + req.path.replace(proxyEndpoint, ''),
           ignorePath: true,
           followRedirects: true,
+          changeOrigin: true,
         })
         proxy(req, res, next)
       })

--- a/lib/storage/kv-storage.ts
+++ b/lib/storage/kv-storage.ts
@@ -8,5 +8,9 @@ export const set = (key: string, value: any) => {
 }
 
 export const get = (key: string) => {
-  return JSON.parse(readFileSync(BASE_DIR + '/' + key).toString())
+  try {
+    return JSON.parse(readFileSync(BASE_DIR + '/' + key).toString())
+  } catch {
+    return
+  }
 }


### PR DESCRIPTION
This allows WebCM to load isolated embeds inside an iframe.

It also includes the following fixes for `manager.get` and `manager.proxy`.